### PR TITLE
Return raw output lines in list

### DIFF
--- a/relay/messages/execution.go
+++ b/relay/messages/execution.go
@@ -42,7 +42,7 @@ type ExecutionResponse struct {
 	Bundle        string      `json:"bundle"`
 	Status        string      `json:"status"`
 	StatusMessage string      `json:"status_message"`
-	Template      interface{} `json:"template"`
+	Template      string      `json:"template,omitempty"`
 	Body          interface{} `json:"body"`
 	IsJSON        bool
 }

--- a/relay/messages/execution.go
+++ b/relay/messages/execution.go
@@ -42,7 +42,7 @@ type ExecutionResponse struct {
 	Bundle        string      `json:"bundle"`
 	Status        string      `json:"status"`
 	StatusMessage string      `json:"status_message"`
-	Template      string      `json:"template"`
+	Template      interface{} `json:"template"`
 	Body          interface{} `json:"body"`
 	IsJSON        bool
 }

--- a/relay/worker/output_parser_test.go
+++ b/relay/worker/output_parser_test.go
@@ -28,11 +28,11 @@ var (
 func TestParseLogOutput(t *testing.T) {
 	req.Parse()
 	resp := &messages.ExecutionResponse{}
-	output := "COGCMD_DEBUG: Testing 123\nabc\n"
+	output := "COGCMD_DEBUG: Testing 123\nabc\n123\n"
 	parseOutput([]byte(output), []byte{}, nil, resp, req)
 	text, _ := json.Marshal(resp.Body)
-	if string(text) != "[{\"body\":\"abc\\n\"}]" {
-		t.Errorf("Unexpected parseOutput result: [{\"body\":\"abc\\n\"}] != %s", string(text))
+	if string(text) != "[{\"body\":[\"abc\",\"123\"]}]" {
+		t.Errorf("Unexpected parseOutput result: [{\"body\":[\"abc\",\"123\"]}] != %s", string(text))
 	}
 }
 


### PR DESCRIPTION
This does two things to allow rendering raw lines of text.
1. Return raw lines in a list instead of a string with newlines like this:
   
   ```
   {
    "body": [
      "this is the first line",
      "this is the second line"
    ]
   }
   ```
2. Allowed the `template` key to be `null` in the marshaled json response.
