### PR TITLE
Fix environment generation for non-string arguments

### DIFF
--- a/relay/engines/env_builder.go
+++ b/relay/engines/env_builder.go
@@ -24,7 +24,7 @@ func BuildEnvironment(request messages.ExecutionRequest, relayConfig config.Conf
 		cogOpts := ""
 		for k, v := range request.Options {
 			optName := fmt.Sprintf("COG_OPT_%s", strings.ToUpper(k))
-			vars[optName] = fmt.Sprintf("%s", v)
+			vars[optName] = fmt.Sprintf("%v", v)
 			if cogOpts == "" {
 				cogOpts = k
 			} else {


### PR DESCRIPTION
Relay builds incorrect environment variables when handling options that have a type that is not string. Examples:

Integer: `%!s(float64=1)`
Bool: `%!s(bool=true)`

This PR changes the environment population code to use `%v` instead of `%s` when building the values of environment variables so that non-string options will be coerced to strings using the string coercion rules for their type.
