### PR TITLE
Treat large integers in JSON as integers

### DIFF
--- a/relay/worker/execution.go
+++ b/relay/worker/execution.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
@@ -59,7 +60,10 @@ func engineForBundle(bundle config.Bundle, config config.Config) (engines.Engine
 
 func executeCommand(invoke *CommandInvocation) {
 	request := &messages.ExecutionRequest{}
-	if err := json.Unmarshal(invoke.Payload, request); err != nil {
+
+	d := json.NewDecoder(bytes.NewReader(invoke.Payload))
+	d.UseNumber()
+	if err := d.Decode(request); err != nil {
 		log.Errorf("Ignoring malformed execution request: %s.", err)
 		return
 	}

--- a/relay/worker/output_parser.go
+++ b/relay/worker/output_parser.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
@@ -62,7 +63,10 @@ func parseOutput(commandOutput []byte, commandErrors []byte, err error, resp *me
 	if resp.IsJSON == true {
 		jsonBody := interface{}(nil)
 		remaining := []byte(strings.Join(retained, "\n"))
-		if err := json.Unmarshal(remaining, &jsonBody); err != nil {
+
+		d := json.NewDecoder(bytes.NewReader(remaining))
+		d.UseNumber()
+		if err := d.Decode(&jsonBody); err != nil {
 			resp.Status = "error"
 			resp.StatusMessage = "Command returned invalid JSON."
 		} else {


### PR DESCRIPTION
Not floats in scientific notation! Without this, we end up
round-tripping big integers as floats, which can cause issues for
downstream commands that expect integers.

Fixes #768
