### PR TITLE
Generalize chat user IDs

### DIFF
--- a/relay/messages/execution.go
+++ b/relay/messages/execution.go
@@ -26,7 +26,7 @@ type ExecutionRequest struct {
 
 // ChatUser contains chat information about the submittor
 type ChatUser struct {
-	ID       string `json:"id"`
+	ID       interface{} `json:"id"` // Slack IDs are strings, HipChat are integers
 	Handle   string `json:"handle"`
 	Provider string `json:"provider"`
 }


### PR DESCRIPTION
Slack IDs are strings, while HipChat IDs are integers, for
example. Without this change, HipChat users wouldn't be able to execute
any commands running on Relay, as their requests would fail to parse and
be subsequently dropped on the ground.
