### PR TITLE
Streamline command dispatch

### DIFF
--- a/relay/config/dynamic_config.go
+++ b/relay/config/dynamic_config.go
@@ -41,6 +41,11 @@ func (c *Config) LoadDynamicConfig(bundle string) map[string]interface{} {
 }
 
 func locateConfigFile(configRoot string, bundle string) string {
+	rootInfo, rootErr := os.Stat(configRoot)
+	if rootErr != nil || rootInfo.IsDir() == false {
+		log.Debugf("Dynamic configuration root dir not found.")
+		return ""
+	}
 	fullYamlPath := path.Join(configRoot, bundle, "config.yaml")
 	fullYmlPath := path.Join(configRoot, bundle, "config.yml")
 	yamlInfo, yamlErr := os.Stat(fullYamlPath)

--- a/relay/messages/env_builder.go
+++ b/relay/messages/env_builder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func (er *ExecutionRequest) compileEnvironment(relayConfig *config.Config) map[string]string {
+func (er *ExecutionRequest) compileEnvironment(relayConfig *config.Config, useDynamicConfig bool) (map[string]string, bool) {
 	vars := make(map[string]string)
 	vars["PATH"] = "/bin:/usr/bin"
 	for i, v := range er.Args {
@@ -40,9 +40,13 @@ func (er *ExecutionRequest) compileEnvironment(relayConfig *config.Config) map[s
 		vars["COG_INVOCATION_STEP"] = er.InvocationStep
 	}
 
-	dyn := relayConfig.LoadDynamicConfig(er.BundleName())
-	for k, v := range dyn {
-		vars[k] = fmt.Sprintf("%s", v)
+	foundDynamicConfig := false
+	if useDynamicConfig {
+		dyn := relayConfig.LoadDynamicConfig(er.BundleName())
+		foundDynamicConfig = len(dyn) > 0
+		for k, v := range dyn {
+			vars[k] = fmt.Sprintf("%s", v)
+		}
 	}
 
 	if relayConfig.Execution != nil {
@@ -54,5 +58,5 @@ func (er *ExecutionRequest) compileEnvironment(relayConfig *config.Config) map[s
 	vars["USER"] = os.Getenv("USER")
 	vars["HOME"] = os.Getenv("HOME")
 	vars["LANG"] = os.Getenv("LANG")
-	return vars
+	return vars, foundDynamicConfig
 }

--- a/relay/messages/execution.go
+++ b/relay/messages/execution.go
@@ -55,17 +55,18 @@ type ExecutionResponse struct {
 }
 
 // ToCircuitRequest converts an ExecutionRequest into a circuit.api.ExecRequest
-func (er *ExecutionRequest) ToCircuitRequest(bundle *config.Bundle, relayConfig *config.Config) api.ExecRequest {
+func (er *ExecutionRequest) ToCircuitRequest(bundle *config.Bundle, relayConfig *config.Config, useDynamicConfig bool) (api.ExecRequest, bool) {
+	callingEnv, hasDynamicConfig := er.compileEnvironment(relayConfig, useDynamicConfig)
 	executable := bundle.Commands[er.commandName].Executable
 	retval := api.ExecRequest{
 		Executable: executable,
-		Env:        er.compileEnvironment(relayConfig),
+		Env:        callingEnv,
 	}
 	if er.CogEnv != nil {
 		jenv, _ := json.Marshal(er.CogEnv)
 		retval.Stdin = jenv
 	}
-	return retval
+	return retval, hasDynamicConfig
 }
 
 // BundleName returns just the bundle part of the

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -75,10 +75,10 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "Nh/JVKKhwPM5aFUZML6GCZIWgGw=",
+			"checksumSHA1": "RyGoYju/gWkb9vL5BtJhaALmaiQ=",
 			"path": "github.com/operable/circuit",
-			"revision": "aeb4f86e9123a42d0dfca0a0f9c4aa49fdc7c457",
-			"revisionTime": "2016-06-15T19:02:12Z"
+			"revision": "0e74d4e48f8b885833815877b00ff49d9b92d056",
+			"revisionTime": "2016-06-21T21:57:24Z"
 		},
 		{
 			"checksumSHA1": "ymFw/xJJ0NSFuP9LDySbbnoMET4=",


### PR DESCRIPTION
This commit optimizes some of Relay's naive behavior wrt command dispatch. The goal is to eliminate unnecessary work on the command dispatch code path.
1. Relay now caches whether or not a command has dynamic config for the duration of a pipeline. Since pipeline steps complete in a few seconds, I don't think this will be impactful to users aside from a slight
   performance increase. Teaching Relay to remember whether or not a command has dynamic config and skip processing when the config isn't found saves 1 - 3 `stat` calls per invocation.
2. Prior to this commit Docker engines would eagerly connect to the Docker daemon even when they didn't require a connection. This has been changed to lazily connect when an engine instance needs to talk to Docker.
