### PR TITLE
Optimizations based on memory and CPU profiling

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"runtime/pprof"
 	"strings"
 	"syscall"
@@ -36,7 +35,6 @@ var configLocations = []string{
 }
 
 func init() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	displayVersionInfo()
 	log.SetFormatter(&log.TextFormatter{
 		DisableTimestamp: false,

--- a/relay/worker/execution.go
+++ b/relay/worker/execution.go
@@ -44,6 +44,7 @@ func ExecutionWorker(queue chan interface{}) {
 		if bufferedReader == nil {
 			bufferedReader = bufio.NewReader(bytes.NewReader(invoke.Payload))
 			decoder = json.NewDecoder(bufferedReader)
+			decoder.UseNumber()
 		} else {
 			bufferedReader.Reset(bytes.NewReader(invoke.Payload))
 		}

--- a/relay/worker/output_parser.go
+++ b/relay/worker/output_parser.go
@@ -34,15 +34,20 @@ func parseOutput(result api.ExecResult, err error, resp *messages.ExecutionRespo
 		lines := strings.Split(strings.TrimSuffix(string(result.Stdout), "\n"), "\n")
 		for _, line := range lines {
 			matched := false
-			for re, cb := range outputParsers {
-				if re.MatchString(line) {
-					lines := re.Split(line, 2)
-					cb(lines, resp, req)
-					matched = true
-					break
+			if resp.IsJSON == false {
+				for re, cb := range outputParsers {
+					if re.MatchString(line) {
+						lines := re.Split(line, 2)
+						cb(lines, resp, req)
+						matched = true
+						break
+					}
 				}
-			}
-			if matched == false {
+				if matched == false {
+					log.Debugf("Before JSON set: %s", line)
+					retained = append(retained, line)
+				}
+			} else {
 				retained = append(retained, line)
 			}
 		}


### PR DESCRIPTION
1. Don't set GOMAXPROCS in code (golang best practice)
2. Reuse JSON decoder to avoid extra allocs and GCs.
3. Stop scanning command output once we know it's JSON.
