### PR TITLE
Change pipeline execution to per-stage

### DIFF
--- a/relay/announcer.go
+++ b/relay/announcer.go
@@ -70,10 +70,6 @@ func NewAnnouncer(relayID string, busOpts bus.ConnectionOptions, catalog *bundle
 // Run connects the announcer to Cog and starts its main
 // loop in a goroutine
 func (ra *relayAnnouncer) Run() error {
-	ra.options.OnDisconnect = &bus.DisconnectMessage{
-		Topic: "bot/relays/discover",
-		Body:  newWill(ra.id, ra.receiptTopic),
-	}
 	ra.options.EventsHandler = ra.handleBusEvents
 	ra.options.OnDisconnect = &bus.DisconnectMessage{
 		Topic: "bot/relays/discover",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -120,6 +120,13 @@
 			"path": "github.com/golang/protobuf/ptypes/any",
 			"revision": "3852dcfda249c2097355a6aabb199a28d97b30df",
 			"revisionTime": "2016-06-29T21:10:53Z"
+        },
+        {
+			"checksumSHA1": "DICLV/1eJgY0WXabRQbvhCsUd20=",
+			"path": "github.com/golang/snappy",
+			"revision": "d9eb7a3d35ec988b8585d4a0068e462c27d28380",
+			"revisionTime": "2016-05-29T05:00:41Z",
+			"tree": true
 		},
 		{
 			"checksumSHA1": "LkmAYl9HJbRrOxw4xWpVc2+TODc=",


### PR DESCRIPTION
This commit does two things:
1. Changes pipeline execution to a per-stage model. This means Cog sends
   an entire stage down to a target Relay and, in turn, receives an entire
   stage of output when the Relay completes execution.
2. Adds snappy compression to all bus traffic. This is meant to address
   the increased message sizes caused by executing an entire stage at a time.
