### PR TITLE
Add volume binding for created containers

### DIFF
--- a/relay/config/bundle_config.go
+++ b/relay/config/bundle_config.go
@@ -22,6 +22,7 @@ type Bundle struct {
 type DockerImage struct {
 	Image string `json:"image" valid:"notempty,required"`
 	Tag   string `json:"tag" valid:"-"`
+	Binds []string `json:"binds"`
 }
 
 // BundleCommand identifies a command within a bundle

--- a/relay/engines/docker.go
+++ b/relay/engines/docker.go
@@ -234,6 +234,7 @@ func (de *DockerEngine) newEnvironment(bundle *config.Bundle) (circuit.Environme
 	options.DockerOptions.Conn = client
 	options.DockerOptions.Image = bundle.Docker.Image
 	options.DockerOptions.Tag = bundle.Docker.Tag
+	options.DockerOptions.Binds = bundle.Docker.Binds
 	options.DockerOptions.DriverInstance = "cog-circuit-driver"
 	options.DockerOptions.DriverPath = "/operable/circuit/bin/circuit-driver"
 	options.DockerOptions.Memory = int64(de.relayConfig.Docker.ContainerMemory * megabyte)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -129,10 +129,10 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "RyGoYju/gWkb9vL5BtJhaALmaiQ=",
+			"checksumSHA1": "7gdVhAPZiIJ9q9nwVmj3oRZ/uAo=",
 			"path": "github.com/operable/circuit",
-			"revision": "0e74d4e48f8b885833815877b00ff49d9b92d056",
-			"revisionTime": "2016-06-21T21:57:24Z"
+			"revision": "b174a76e6e0be91517256f509cf92d67f0cc7da7",
+			"revisionTime": "2016-07-15T20:39:28Z"
 		},
 		{
 			"checksumSHA1": "GzyPG5aJRqO7rgNoQkMxl0QwO6g=",


### PR DESCRIPTION
See also https://github.com/operable/circuit/pull/1 (which will need to be referenced in `vendor/vendor.json` when merged)

Fixes operable/cog#838
