### PR TITLE
Added -dev flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ const (
 
 var configFile = flag.String("file", "", "Path to configuration file")
 var cpuprofile = flag.String("cpuprofile", "", "Write CPU profile to file")
-var memprofile = flag.String("memprofile", "", "write memory profile to this file")
+var memprofile = flag.String("memprofile", "", "Write memory profile to this file")
+var devMode    = flag.Bool("dev", false, "Enable developer mode")
 
 // Populated by build script
 var buildstamp string
@@ -139,6 +140,7 @@ func prepare() *config.Config {
 		os.Exit(BAD_CONFIG)
 		return nil
 	}
+	relayConfig.DevMode = *devMode
 	configureLogger(relayConfig)
 	return relayConfig
 }
@@ -169,7 +171,9 @@ func main() {
 		return
 	}
 	log.Infof("Relay %s is initializing.", relayConfig.ID)
-
+	if relayConfig.DevMode == true {
+		log.Warn("Developer mode enabled.")
+	}
 	myRelay, err := relay.NewRelay(relayConfig)
 	if err != nil {
 		log.Error(err)

--- a/relay/config/config.go
+++ b/relay/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	Cog                   *CogInfo `yaml:"cog" valid:"required"`
 	EnginesEnabled        string   `yaml:"enabled_engines" env:"RELAY_ENABLED_ENGINES" valid:"exec_engines" default:"docker,native"`
 	ParsedEnginesEnabled  []string
+	DevMode               bool
 	Docker                *DockerInfo    `yaml:"docker" valid:"-"`
 	Execution             *ExecutionInfo `yaml:"execution" valid:"-"`
 }


### PR DESCRIPTION
Adds the `-dev` flag to Relay's CLI. Setting it tells Relay to run in development mode where it trades speed for developer productivity.

This PR adds the flag definition, glue logic to patch the flag into Relay's configuration, and enables pulls and re-pulls of Docker images before each command execution for commands packaged in Docker images.

Fixes [#950](https://github.com/operable/cog/issues/950)
