### PR TITLE
Drive response error from exit status, not stderr

### DIFF
--- a/relay/worker/output_parser_v1.go
+++ b/relay/worker/output_parser_v1.go
@@ -71,7 +71,7 @@ func (op *OutputParserV1) Parse(result api.ExecResult, req messages.ExecutionReq
 			}
 		}
 	}
-	if len(result.Stderr) > 0 {
+	if !result.GetSuccess() {
 		resp.Status = "error"
 		resp.StatusMessage = string(result.Stderr)
 		return resp

--- a/relay/worker/output_parser_v1_test.go
+++ b/relay/worker/output_parser_v1_test.go
@@ -35,6 +35,7 @@ func TestParseLogOutput(t *testing.T) {
 		Stdout: []byte("COGCMD_DEBUG: Testing 123\nabc\n123\n"),
 		Stderr: emptyStream,
 	}
+	result.SetSuccess(true)
 	resp := outputParser.Parse(result, req, nil)
 	text, _ := json.Marshal(resp.Body)
 	if string(text) != "[{\"body\":[\"abc\",\"123\"]}]" {
@@ -48,6 +49,7 @@ func TestDetectJSON(t *testing.T) {
 		Stdout: []byte("COGCMD_INFO: Testing123\nJSON\n{\"foo\": 123}"),
 		Stderr: emptyStream,
 	}
+	result.SetSuccess(true)
 	resp := outputParser.Parse(result, req, nil)
 	text, _ := json.Marshal(resp.Body)
 	if string(text) != "{\"foo\":123}" {
@@ -61,5 +63,43 @@ func TestNoOutput(t *testing.T) {
 	resp := outputParser.Parse(result, req, nil)
 	if resp.Body != nil {
 		t.Errorf("Unexpected parseOutput result: %s", resp.Body)
+	}
+}
+
+
+func TestNoErrorIfResultIsSuccess(t *testing.T) {
+	req.Parse()
+	result := api.ExecResult{
+		Stdout: []byte("Yay, output"),
+		Stderr: []byte("Some supplementary output"),
+	}
+	result.SetSuccess(true)
+	resp := outputParser.Parse(result, req, nil)
+
+	if resp.Status != "ok" {
+		t.Errorf("Unexpected response status %s", resp.Status)
+	}
+
+	text, _ := json.Marshal(resp.Body)
+	if string(text) != "[{\"body\":[\"Yay, output\"]}]" {
+		t.Errorf("Unexpected body %s", text)
+	}
+}
+
+func TestErrorOnlyIfResultIsNotSuccess(t *testing.T) {
+	req.Parse()
+	result := api.ExecResult{
+		Stdout: []byte("Yay, output"),
+		Stderr: []byte("Bad stuff happened"),
+	}
+	result.SetSuccess(false)
+	resp := outputParser.Parse(result, req, nil)
+
+	if resp.Status == "ok" {
+		t.Errorf("Unexpected response status %s", resp.Status)
+	}
+
+	if resp.StatusMessage != "Bad stuff happened" {
+		t.Errorf("Unexpected response status message %s", resp.StatusMessage)
 	}
 }


### PR DESCRIPTION
Previously, a command would be marked as an error if standard error contained any data, regardless of the actual exit code of the command (0 = success, >0 = failure).

This would be especially problematic for commands that wrap existing executables which output additional information on standard error, reserving standard output for the "real" output of the program.

Now, we rely on the exit status only.
