### PR TITLE
Exit when disconnected

### DIFF
--- a/relay/bus/mqtt.go
+++ b/relay/bus/mqtt.go
@@ -69,18 +69,7 @@ func (mqc *MQTTConnection) Subscribe(topic string, handler SubscriptionHandler) 
 }
 
 func (mqc *MQTTConnection) disconnected(cilent *mqtt.Client, err error) {
-	for {
-		if token := mqc.conn.Connect(); token.Wait() && token.Error() != nil {
-			log.Errorf("Connection to %s failed.", mqc.options.Host)
-			mqc.backoff.Wait()
-		} else {
-			mqc.backoff.Reset()
-			break
-		}
-	}
-	if mqc.options.EventsHandler != nil {
-		mqc.options.EventsHandler(mqc, ConnectedEvent)
-	}
+	log.Fatalf("Connection to Cog has failed: %s", err)
 }
 
 func (mqc *MQTTConnection) buildMQTTOptions(options ConnectionOptions) *mqtt.ClientOptions {


### PR DESCRIPTION
This commit causes Relay to exit when it's disconnected from Cog. Users
will need to use an external process supervisor, like Docker, systemd,
or runit, to restart failed Relay processes.

Fixes https://github.com/operable/cog/issues/990
