### PR TITLE
Added dev mode awareness to needsUpdate()

### DIFF
--- a/relay/engines/docker.go
+++ b/relay/engines/docker.go
@@ -276,6 +276,12 @@ func (de *DockerEngine) needsUpdate(name, meta string) bool {
 	if meta != "latest" {
 		image, _, _ := de.client.ImageInspectWithRaw(context.Background(), fullName, false)
 		if image.ID != "" {
+			// Override when DevMode is enabled
+			if name != "operable/circuit-driver" && de.relayConfig.DevMode == true {
+				log.Warnf("Developer mode: Marked %s stale even though local image %s exists.",
+					fullName, shortImageID(image.ID))
+				return true
+			}
 			log.Debugf("Resolved Docker image name %s to %s.", fullName, shortImageID(image.ID))
 			return false
 		}


### PR DESCRIPTION
Prior to this commit the `-dev` flag was only considered when a command
was run. This meant Relay would consider images up to date at startup
rather than attempting to pull a new image.

This change modifies Relay's staleness checking logic to consider all
images to be stale when `-dev` is in effect during startup, periodic
registry refreshes, and command invocations.

The `operable/circuit-driver` image is omitted from this behavior since
it's integral to Relay's function and doesn't change often.

Fixes operable/cog#997
