### PR TITLE
Remove references to cog-relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 vendor/*/
-cog-relay
 *-test
 *.test
 **/*.test
 */**/*.test
-cog-relay_*
 *.tar.gz
 _build

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Docker v1.10.3+
    make
    ```
 
-3. Set environment variables and run `cog-relay`.
+3. Set environment variables and run `relay`.
 
    You'll need to have a docker machine running and have environment variables
    set for the docker client to connect to it. If you haven't already, run the
@@ -35,5 +35,5 @@ Docker v1.10.3+
    Then start relay:
 
    ```
-   RELAY_DOCKER_USE_ENV=true ./cog-relay -file example_cog_relay.conf
+   RELAY_DOCKER_USE_ENV=true _build/relay -file example_cog_relay.conf
    ```


### PR DESCRIPTION
The built executable is named relay and placed in the _build directory.
All references to cog-relay executable have been removed.
