### PR TITLE
Exit with a specific exit code when a restart is required

### DIFF
--- a/relay/bus/mqtt.go
+++ b/relay/bus/mqtt.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"os"
 	log "github.com/Sirupsen/logrus"
 	"github.com/eclipse/paho.mqtt.golang"
 	"io/ioutil"
@@ -69,7 +70,8 @@ func (mqc *MQTTConnection) Subscribe(topic string, handler SubscriptionHandler) 
 }
 
 func (mqc *MQTTConnection) disconnected(cilent *mqtt.Client, err error) {
-	log.Fatalf("Connection to Cog has failed: %s", err)
+	log.Errorf("Connection to Cog has failed: %s", err)
+	os.Exit(3)
 }
 
 func (mqc *MQTTConnection) buildMQTTOptions(options ConnectionOptions) *mqtt.ClientOptions {


### PR DESCRIPTION
Since f0e0b852 we `Exit()` when the relay is disconnected from Cog as a
trigger to the supervisor that the process has to be restarted.

In order for the supervisor to distinguish between generic errors and
restart requests a new exit code is introduced. This fits well with
Systemd's `RestartForceExitStatus=` directive.
