### PR TITLE
Run Engine.SetAvailable() on all engines

### DIFF
--- a/relay/engines/native.go
+++ b/relay/engines/native.go
@@ -31,7 +31,7 @@ func (ne *NativeEngine) Init() error {
 }
 
 // IsAvailable required by engines.Engine interface
-func (ne *NativeEngine) IsAvailable(name string, meta string) (bool, error) {
+func (ne *NativeEngine) IsAvailable(name string, version string) (bool, error) {
 	return true, nil
 }
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -230,7 +230,9 @@ func (r *cogRelay) refreshBundles() error {
 					avail, _ := dockerEngine.IsAvailable(bundle.Docker.Image, bundle.Docker.Tag)
 					bundle.SetAvailable(avail)
 				} else {
-					r.catalog.MarkReady(bundle.Name)
+					engine, _ := r.engines.EngineForBundle(bundle)
+					avail, _ := engine.IsAvailable(bundle.Name, bundle.Version)
+					bundle.SetAvailable(avail)
 				}
 			}
 		}


### PR DESCRIPTION
SetAvailable() was invoked only for the docker engine, since it is the
only engine that actually hooks its fetching logic there.

The side-effect was that a new engine would not have an entry point for
fetching a bundle.
