### PR TITLE
Create log file if it doesn't exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func configureLogger(config *config.Config) {
 	case "stdout":
 		log.SetOutput(os.Stdout)
 	default:
-		logFile, err := os.Open(config.LogPath)
+		logFile, err := os.OpenFile(config.LogPath, os.O_WRONLY | os.O_APPEND | os.O_CREATE, 0644)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes operable/cog#1123

Initially I thought of handling log rotation with this change as well, but decided against it for the time being. The current change fixes the original functionality that was intended to be present, and no more. To properly support log rotation, we'd need to either monitor inodes, reopen the file for each write (something that https://github.com/rifflock/lfshook actually does, and I initially thought to use, though that requires a little more work to mirror the functionality we currently have), or (my current inclination) implement a signal handler for `SIGHUP` which would reopen log files (and probably config files, too), in keeping with many other UNIX programs, and easily utilized with programs like `logrotate`. (Right now, a `SIGHUP` will terminate the Relay process, which is default behavior for Go programs.)