### PR TITLE
Expose COG_USERNAME & COG_EMAIL in command environment

### DIFF
--- a/relay/messages/env_builder.go
+++ b/relay/messages/env_builder.go
@@ -45,6 +45,8 @@ func (er *ExecutionRequest) compileEnvironment(request *api.ExecRequest, relayCo
 	request.PutEnv("COG_COMMAND", er.CommandName())
 	request.PutEnv("COG_ROOM", er.Room.Name)
 	request.PutEnv("COG_CHAT_HANDLE", er.Requestor.Handle)
+	request.PutEnv("COG_USERNAME", er.User.Username)
+	request.PutEnv("COG_EMAIL", er.User.Email)
 	request.PutEnv("COG_PIPELINE_ID", er.PipelineID())
 	request.PutEnv("COG_SERVICE_TOKEN", er.ServiceToken)
 	request.PutEnv("COG_SERVICES_ROOT", er.ServicesRoot)


### PR DESCRIPTION
Closes operable/cog#1152

The two extra variables can be quite useful in integrating cog with other systems. As an example, in https://github.com/skroutz/cogy , we can use those to map a chat user to an application user object.