### PR TITLE
Set sane defaults

### DIFF
--- a/example_relay.conf
+++ b/example_relay.conf
@@ -24,7 +24,7 @@ max_concurrent: 8
 # Use managed dynamic configuration
 # Requires dynamic_config_root
 # Environment variable: $RELAY_MANAGED_DYNAMIC_CONFIG
-# Default: false
+# Default: true
 # managed_dynamic_config: false
 
 # Refresh interval for managed dynamic configuration files.

--- a/relay/config/config.go
+++ b/relay/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	ID                    string   `yaml:"id" env:"RELAY_ID" valid:"uuid,required"`
 	MaxConcurrent         int      `yaml:"max_concurrent" env:"RELAY_MAX_CONCURRENT" valid:"int64,required" default:"16"`
 	DynamicConfigRoot     string   `yaml:"dynamic_config_root" env:"RELAY_DYNAMIC_CONFIG_ROOT" valid:"-"`
-	ManagedDynamicConfig  bool     `yaml:"managed_dynamic_config" env:"RELAY_MANAGED_DYNAMIC_CONFIG" valid:"-"`
+	ManagedDynamicConfig  bool     `yaml:"managed_dynamic_config" env:"RELAY_MANAGED_DYNAMIC_CONFIG" valid:"bool" default:"true"`
 	DynamicConfigInterval string   `yaml:"managed_dynamic_config_interval" env:"RELAY_MANAGED_DYNAMIC_CONFIG_INTERVAL" default:"5s"`
 	LogLevel              string   `yaml:"log_level" env:"RELAY_LOG_LEVEL" valid:"required" default:"info"`
 	LogJSON               bool     `yaml:"log_json" env:"RELAY_LOG_JSON" valid:"bool" default:"false"`

--- a/relay/config/raw.go
+++ b/relay/config/raw.go
@@ -36,6 +36,7 @@ func (rc RawConfig) Parse(dockerDriverTag string) (*Config, error) {
 		}
 	}
 	config.populate()
+	config.ID = strings.ToLower(config.ID)
 	if config.Docker.CommandDriverVersion == "" {
 		config.Docker.CommandDriverVersion = dockerDriverTag
 	}


### PR DESCRIPTION
The only issue with this is that now `RELAY_DYNAMIC_CONFIG_ROOT` will not be required by default unless `RELAY_MANAGED_DYNAMIC_CONFIG` is set to `false`. I couldn't' think of a sane default for that var so for now it'll just error out if not set.

Closes https://github.com/operable/cog/issues/1147