### PR TITLE
Run commands with env vars defined in the bundle config

### DIFF
--- a/relay/config/bundle_config.go
+++ b/relay/config/bundle_config.go
@@ -20,8 +20,8 @@ type Bundle struct {
 
 // DockerImage identifies the bundle's image name and version
 type DockerImage struct {
-	Image string `json:"image" valid:"notempty,required"`
-	Tag   string `json:"tag" valid:"-"`
+	Image string   `json:"image" valid:"notempty,required"`
+	Tag   string   `json:"tag" valid:"-"`
 	Binds []string `json:"binds"`
 }
 
@@ -31,6 +31,7 @@ type BundleCommand struct {
 	Executable string                          `json:"executable" valid:"required"`
 	Options    map[string]*BundleCommandOption `json:"options"`
 	Rules      []string                        `json:"rules"`
+	EnvVars    map[string]string               `json:"env_vars"`
 }
 
 // BundleCommandOption is a description of a command's option

--- a/relay/messages/env_builder.go
+++ b/relay/messages/env_builder.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func (er *ExecutionRequest) compileEnvironment(request *api.ExecRequest, relayConfig *config.Config, useDynamicConfig bool) bool {
+func (er *ExecutionRequest) compileEnvironment(command *config.BundleCommand, request *api.ExecRequest, relayConfig *config.Config, useDynamicConfig bool) bool {
 	for i, v := range er.Args {
 		request.PutEnv(fmt.Sprintf("COG_ARGV_%d", i), fmt.Sprintf("%v", v))
 	}
@@ -54,6 +54,10 @@ func (er *ExecutionRequest) compileEnvironment(request *api.ExecRequest, relayCo
 
 	if er.InvocationStep != "" {
 		request.PutEnv("COG_INVOCATION_STEP", er.InvocationStep)
+	}
+
+	for k, v := range command.EnvVars {
+		request.PutEnv(k, fmt.Sprintf("%s", v))
 	}
 
 	foundDynamicConfig := false

--- a/relay/messages/execution.go
+++ b/relay/messages/execution.go
@@ -17,7 +17,6 @@ type ExecutionRequest struct {
 	InvocationID   string                 `json:"invocation_id"`
 	InvocationStep string                 `json:"invocation_step"`
 	Command        string                 `json:"command"`
-	CommandConfig  map[string]interface{} `json:"command_config"`
 	ReplyTo        string                 `json:"reply_to"`
 	Requestor      ChatUser               `json:"requestor"`
 	User           CogUser                `json:"user"`
@@ -53,7 +52,7 @@ type CogUser struct {
 // return a map with at least a "name" key. Formalization work is
 // underway, however.
 type ChatRoom struct {
-	Name      string `json:"name"`
+	Name string `json:"name"`
 }
 
 // ExecutionResponse contains the results of executing a command
@@ -73,11 +72,11 @@ var errorCommandNotFound = errors.New("Command not found")
 // ToCircuitRequest converts an ExecutionRequest into a circuit.api.ExecRequest
 func (er *ExecutionRequest) ToCircuitRequest(bundle *config.Bundle, relayConfig *config.Config, useDynamicConfig bool) (*api.ExecRequest, bool, error) {
 	retval := &api.ExecRequest{}
-	hasDynamicConfig := er.compileEnvironment(retval, relayConfig, useDynamicConfig)
-	command := bundle.Commands[er.commandName]
+	command := bundle.Commands[er.CommandName()]
 	if command == nil {
 		return nil, false, errorCommandNotFound
 	}
+	hasDynamicConfig := er.compileEnvironment(command, retval, relayConfig, useDynamicConfig)
 	retval.SetExecutable(command.Executable)
 	if er.CogEnv != nil {
 		jenv, _ := json.Marshal(er.CogEnv)


### PR DESCRIPTION
This allows bundle authors to include environment variables for each command in their bundle configs which are included in the environment when running the command. They are overridden by any dynamic config if available as it is applied afterwards. No change in Cog is necessary since we have already been expecting it in our bundle config schema.