### PR TITLE
Log MQTT connection errors

### DIFF
--- a/relay/bus/mqtt.go
+++ b/relay/bus/mqtt.go
@@ -31,7 +31,7 @@ func (mqc *MQTTConnection) Connect(options ConnectionOptions) error {
 	mqc.conn = mqtt.NewClient(mqttOpts)
 	for {
 		if token := mqc.conn.Connect(); token.Wait() && token.Error() != nil {
-			log.Errorf("Error connecting to %s.", brokerURL(options))
+			log.Errorf("Error connecting to %s: %s", brokerURL(options), token.Error())
 			mqc.backoff.Wait()
 		} else {
 			mqc.backoff.Reset()
@@ -72,7 +72,7 @@ func (mqc *MQTTConnection) disconnected(cilent *mqtt.Client, err error) {
 	log.Errorf("MQTT connection failed: %s.", err)
 	for {
 		if token := mqc.conn.Connect(); token.Wait() && token.Error() != nil {
-			log.Errorf("Error connecting to %s.", brokerURL(mqc.options))
+			log.Errorf("Error connecting to %s: %s", brokerURL(mqc.options), token.Error())
 			mqc.backoff.Wait()
 		} else {
 			mqc.backoff.Reset()


### PR DESCRIPTION
Now a log line might look like this:
```
ERRO[2016-12-12T11:53:04-05:00] Error connecting to tcp://127.0.0.1:1883: Network Error : dial tcp 127.0.0.1:1883: getsockopt: connection refused
```

(That was running Relay with no Cog server running.)

Hopefully this can help shed a bit of light when Relay can't connect
to Cog.