### PR TITLE
Ping docker for server version

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -52,10 +52,12 @@
 			"revisionTime": "2016-12-09T17:51:46Z"
 		},
 		{
-			"checksumSHA1": "dTftUF4Gpn7O82maeci1uf38A7k=",
+			"checksumSHA1": "YBWdvq03F8tkXRmh9qfcU8otV1Q=",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "9d884986f5c001cacb60aa3c50036575ed2dd22d",
-			"revisionTime": "2016-12-09T17:12:08Z"
+			"revision": "092cba3727bb9b4a2f0e922cd6c0f93ea270e363",
+			"revisionTime": "2017-02-08T05:58:41Z",
+			"version": "v1.13.1",
+			"versionExact": "v1.13.1"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
@@ -136,10 +138,12 @@
 			"revisionTime": "2016-12-09T17:12:08Z"
 		},
 		{
-			"checksumSHA1": "ng4SVYB9pLsANYNhqzsEo7mVznM=",
+			"checksumSHA1": "pub6PN8cGAz8DYjMDkxP6l9VHRg=",
 			"path": "github.com/docker/docker/client",
-			"revision": "9d884986f5c001cacb60aa3c50036575ed2dd22d",
-			"revisionTime": "2016-12-09T17:12:08Z"
+			"revision": "092cba3727bb9b4a2f0e922cd6c0f93ea270e363",
+			"revisionTime": "2017-02-08T05:58:41Z",
+			"version": "v1.13.1",
+			"versionExact": "v1.13.1"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",


### PR DESCRIPTION
Previously if there was a mismatch between the client and server
versions of the docker library we were using, we didn't have a way to
recover so crashing with an error message was the best we could do. The
user would then have to provide a DOCKER_API_VERSION env var to make
sure the client could connect with the correct version.

In the 1.13.x version of the docker client library a ping call was
introduced, which returns a new header with the server version number.
Now, after creating a client, we can ping the server to check its
version number. If that version number is lower than the client, we can
easily downgrade the client. The only case we still can't recover from
is when the server version is higher than the client, which would
probably require a client lib update in Relay.

This is the same method used in the docker cli: https://github.com/docker/docker/blob/1.13.x/cli/command/cli.go#L158-L170

Fixes https://github.com/operable/cog/issues/1346