### PR TITLE
Build static Relay executable for Linux

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,3 +5,25 @@ steps:
       docker-compose:
         run: test
         config: docker-compose.ci.yml
+
+  - wait
+
+  - label: ":linux: Build Executable"
+    command: .buildkite/scripts/build_executable.sh
+
+  - wait
+
+  - label: "Smoke Test on :ubuntu:"
+    command: .buildkite/scripts/smoke_test.sh
+    env:
+      IMAGE: ubuntu:16.10
+
+  - label: "Smoke test on Alpine"
+    command: .buildkite/scripts/smoke_test.sh
+    env:
+      IMAGE: alpine:3.4
+
+  - wait
+
+  - label: ":docker: Build Image"
+    command: .buildkite/scripts/build_image.sh

--- a/.buildkite/scripts/build_executable.sh
+++ b/.buildkite/scripts/build_executable.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+image="operable/relay:builder-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}"
+
+echo "--- :docker: Building ${image}"
+docker build -t "$image" -f Dockerfile.builder .
+
+executable_name="relay-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}"
+echo "--- Extracting executable as ${executable_name}"
+# Need to define an entrypoint for this to work
+# TODO: rework the Dockerfile to do this
+container_id=$(docker create --entrypoint sh "$image")
+docker cp "${container_id}:/usr/local/bin/relay" "${executable_name}"
+docker rm "${container_id}"
+
+echo "--- :buildkite: Uploading ${executable_name}"
+buildkite-agent artifact upload "${executable_name}"
+
+buildkite-agent meta-data set "executable" "${executable_name}"

--- a/.buildkite/scripts/build_image.sh
+++ b/.buildkite/scripts/build_image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Download a relay executable (the name of which is stored in metadata
+# under the name "executable") and inject it into a new Docker image.
+
+set -euo pipefail
+
+executable_name=$(buildkite-agent meta-data get executable)
+echo "--- Downloading artifact ${executable_name}"
+buildkite-agent artifact download "${executable_name}" .
+chmod a+x "${executable_name}"
+mkdir _build
+cp "${executable_name}" _build/relay
+
+export DOCKER_IMAGE="operable/relay-testing:${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}"
+echo "--- Building image ${DOCKER_IMAGE}"
+make do-docker-build
+
+echo "--- Pushing ${DOCKER_IMAGE}"
+docker push "${DOCKER_IMAGE}"

--- a/.buildkite/scripts/smoke_test.sh
+++ b/.buildkite/scripts/smoke_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Download a relay executable (the name of which is stored in metadata
+# under the name "executable") and see if it can actually run
+# in a Docker image, specified by $IMAGE
+
+set -euo pipefail
+
+executable_name=$(buildkite-agent meta-data get executable)
+buildkite-agent artifact download "${executable_name}" .
+chmod a+x "${executable_name}"
+
+# Just try to find out the version of relay. We're just trying to see
+# that the executable can even run on this platform.
+echo "--- Running ${executable_name} on ${IMAGE}"
+docker run \
+       -it \
+       --rm \
+       -v $(pwd):/testing \
+       "${IMAGE}" /testing/${executable_name} --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,9 @@ FROM alpine:3.4
 
 MAINTAINER Kevin Smith <kevin@operable.io>
 
-ARG GIT_COMMIT
-ENV GIT_COMMIT ${GIT_COMMIT:-master}
-
 # Bake in a directory that we can use for logging, config, etc.
 RUN mkdir -p /var/operable/relay
 
-RUN mkdir -p /root/golang/src/github.com/operable/ && \
-  cd /root/golang/src/github.com/operable && \
-  apk add -U --no-cache git go make ca-certificates && \
-  git clone https://github.com/operable/go-relay && \
-  cd go-relay && git checkout $GIT_COMMIT && \
-  GOPATH=/root/golang make exe && \
-  cp _build/relay /usr/local/bin && \
-  mkdir -p /usr/local/etc && \
-  cp docker/relay.conf /usr/local/etc/relay.conf && \
-  cd /root && rm -rf golang && \
-  apk del --force --rdepends --purge go make git && rm -rf /var/cache/apk/*
+# Relies on the binary having already been built
+COPY _build/relay /usr/local/bin
+COPY docker/relay.conf /usr/local/etc/relay.conf

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,23 @@
+FROM ubuntu:16.10
+
+# This is actually Go 1.6.3, despite appearances (as determined by
+# running `go version`)
+ENV GO_PACKAGE_VERSION 2:1.6.1+1ubuntu2
+ENV GOPATH /gopath
+
+RUN apt-get update && \
+    apt-get install -y \
+            git \
+            golang-go=$GO_PACKAGE_VERSION
+
+RUN go get -u github.com/kardianos/govendor
+RUN go get -u github.com/golang/lint/golint
+
+WORKDIR /gopath/src/github.com/operable/go-relay
+COPY . /gopath/src/github.com/operable/go-relay
+RUN make exe
+
+# NOTE: This is not intended to be an Ubuntu Relay image for
+# deployment, so it doesn't have a config file in place. It's just for
+# building a binary.
+RUN mv _build/relay /usr/local/bin


### PR DESCRIPTION
Users have expressed interest in running the bare Relay executable
outside of a Docker environment. Now, we build one on each CI
run (though this isn't yet uploaded to any artifact repository).

In the course of doing this work, it became apparent that the Relay
executable we had been building wasn't actually a statically-linked
executable, and so it would only run on Alpine Linux systems (actually,
a Linux system with musl installed). By using `CGO_ENABLED=0` in our
build step, we can build a static binary, but need to do this on
Ubuntu. (There appear to be additional approaches we could take to build
on Alpine, but it's not really worth it at this point.)

Now, our Docker image build is slightly more involved, in that we build
the executable, and then inject it into a bare-bones container
image. This allows us to not carry around the Go toolchain in the image
layer history. Note that you can still run `make exe` to generate a
binary on your current platform. Running `make docker`, though, will
always generate a Linux executable.

Test images are pushed to the operable/relay-testing repository on
Docker Hub.

Fixes operable/cog#1291