### PR TITLE
New dockerfile that can build by itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ test:
 ci-coveralls: tools deps
 	goveralls -service=travis-ci
 
+# Builds Relay on the current OS
 exe: clean-dev | $(BUILD_DIR)
 	CGO_ENABLED=0 govendor build -ldflags "$(LINK_VARS)" -o $(BUILD_DIR)/$(EXENAME)
 
-docker: export GOOS=linux
-docker: export GOARCH=amd64
-docker: clean exe do-docker-build
+docker:
+	docker build -t $(DOCKER_IMAGE) .
 
 clean: clean-dev
 	rm -rf $(BUILD_DIR) relay-test
@@ -73,9 +73,3 @@ $(TARBALL_NAME): test exe
 	cp example_relay.conf $(TARBALL_NAME)
 	tar czf $(TARBALL_NAME).tar.gz $(TARBALL_NAME)
 	rm -rf $(TARBALL_NAME)
-
-# Providing this solely for CI-built images. We will have already
-# built the executable in a separate step. We split things up because
-# we build inside a Docker image in CI (we don't have Go on builders).
-do-docker-build:
-	docker build -t $(DOCKER_IMAGE) .


### PR DESCRIPTION
Previously, we'd build a glibc Relay locally and then stuff that into a
minimal Docker image and provide that. Now, we do the build of Relay
inside the image build itself. I have confirmed that an executable built
in this Alpine image runs fine in a Debian (i.e., glibc) system.

However, this results in a larger image size right now. Compare the
previous sizes to what is currently built by this commit:

| Image    | Compressed | Uncompressed |
| -------- | ---------- | ------------ |
| Previous | 6 MB       | 19.9 MB      |
| Current  | 30 MB      | 81.6 MB      |

This allows us to easily automate the build with DockerHub, though,
because it doesn't require anything besides the Dockerfile.

See operable/cog#1384 for more.