### PR TITLE
Change flag for config file to "-c,--config"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk -U add --virtual .build_deps \
     git make && \
 
     go get -u github.com/kardianos/govendor && \
+    go get -u github.com/spf13/pflag && \
     make exe && \
 
     mv _build/relay /usr/local/bin && \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -11,8 +11,9 @@ RUN apt-get update && \
             git \
             golang-go=$GO_PACKAGE_VERSION
 
-RUN go get -u github.com/kardianos/govendor
 RUN go get -u github.com/golang/lint/golint
+RUN go get -u github.com/kardianos/govendor
+RUN go get -u github.com/spf13/pflag
 
 WORKDIR /gopath/src/github.com/operable/go-relay
 COPY . /gopath/src/github.com/operable/go-relay

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,6 +3,7 @@ FROM operable/go:1.6.3
 ENV PATH=${GOPATH}/bin:${PATH}
 # Add goveralls for sending stats to coveralls.io in Travis CI
 RUN go get github.com/mattn/goveralls
+RUN go get github.com/spf13/pflag
 
 COPY . $GOPATH/src/github.com/operable/go-relay
 WORKDIR $GOPATH/src/github.com/operable/go-relay

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -12,6 +11,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/operable/go-relay/relay"
 	"github.com/operable/go-relay/relay/config"
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -20,10 +20,10 @@ const (
 	BUS_ERR
 )
 
-var configFile = flag.String("file", "", "Path to configuration file")
+var configFile = flag.StringP("config", "c", "", "Path to configuration file")
 var cpuprofile = flag.String("cpuprofile", "", "Write CPU profile to file")
 var memprofile = flag.String("memprofile", "", "Write memory profile to this file")
-var devMode    = flag.Bool("dev", false, "Enable developer mode")
+var devMode = flag.Bool("dev", false, "Enable developer mode")
 
 // Populated by build script
 var buildstamp string
@@ -70,7 +70,7 @@ func configureLogger(config *config.Config) {
 	case "stdout":
 		log.SetOutput(os.Stdout)
 	default:
-		logFile, err := os.OpenFile(config.LogPath, os.O_WRONLY | os.O_APPEND | os.O_CREATE, 0644)
+		logFile, err := os.OpenFile(config.LogPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Breaking change for anyone who may be specifying their relay config file from the command line.

```
$ ./relay --help
Usage of ./relay:
  -c, --config string       Path to configuration file
      --cpuprofile string   Write CPU profile to file
      --dev                 Enable developer mode
      --memprofile string   Write memory profile to this file
```