### PR TITLE
Update Go language version 1.6.3 -> 1.9.0, as well as Alpine 3.4 -> 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.4
+FROM golang:1.9.0-alpine3.6
 
 MAINTAINER Christopher Maier <christopher.maier@gmail.com>
 
-ENV GO_PACKAGE_VERSION 1.6.3-r0
 ENV GOPATH /gopath
 ENV PATH=${GOPATH}/bin:${PATH}
 
@@ -10,8 +9,6 @@ WORKDIR /gopath/src/github.com/operable/go-relay
 COPY . /gopath/src/github.com/operable/go-relay
 
 RUN apk -U add --virtual .build_deps \
-    go=$GO_PACKAGE_VERSION \
-    go-tools=$GO_PACKAGE_VERSION \
     git make && \
 
     go get -u github.com/kardianos/govendor && \
@@ -27,3 +24,5 @@ RUN apk -U add --virtual .build_deps \
     apk del .build_deps && \
     rm -Rf /var/cache/apk/* && \
     rm -Rf $GOPATH
+
+ENTRYPOINT ["/usr/local/bin/relay"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,3 @@ RUN apk -U add --virtual .build_deps \
     apk del .build_deps && \
     rm -Rf /var/cache/apk/* && \
     rm -Rf $GOPATH
-
-ENTRYPOINT ["/usr/local/bin/relay"]


### PR DESCRIPTION
Fixes #80. 

Definitely open to discussion about how this was done. The previous image base was Alpine itself, and then went on to install Go using the Alpine installer. Alpine 3.4 doesn't have recent versions of Go available, and as it turns out, even Alpine 3.6 doesn't have the package available yet.

The `golang` image used is Alpine 3.6 and builds Go from source. My largest argument against using the official `golang` image would ordinarily be size but this Alpine image is only ~80MB instead of ~270MB for something like Debian.

I built the Docker image and ran it with Cog, everything seemed to be working.