### PR TITLE
Upgrade Ubuntu version (and golang version) in builder

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,8 +1,8 @@
-FROM ubuntu:16.10
+FROM ubuntu:17.10
 
-# This is actually Go 1.6.3, despite appearances (as determined by
+# This is actually Go 1.8.3, despite appearances (as determined by
 # running `go version`)
-ENV GO_PACKAGE_VERSION 2:1.6.1+1ubuntu2
+ENV GO_PACKAGE_VERSION 2:1.8~1ubuntu1
 ENV GOPATH /gopath
 ENV PATH=${GOPATH}/bin:${PATH}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Dependencies
 
-* Go v1.6+
+* Go v1.9+
 * Docker v1.10.3+
 
 ## Getting up and running

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -38,7 +38,7 @@ docker rm "${container_id}"
 
 chmod a+x "${executable_name}"
 
-for PLATFORM in alpine:3.4 ubuntu:16.10
+for PLATFORM in alpine:3.4 ubuntu:17.10
 do
     echo "--- Running ${executable_name} on ${PLATFORM}"
     set -x


### PR DESCRIPTION
Travis builds were failing because Ubuntu 16.10 could not find all of
it's package repository indexes. Using a newer version of Ubuntu
resolved that issue. go package revs from 1.6.3 -> 1.8.3