### PR TITLE
mqtt config fixes

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -147,9 +147,10 @@ func (r *cogRelay) handleBusEvents(conn bus.Connection, event bus.Event) {
 		}
 		if r.catalog.Len() > 0 {
 			r.catalog.Reconnected()
+		} else {
+			log.Info("Loading bundle catalog.")
+			r.requestBundles()
 		}
-		log.Info("Loading bundle catalog.")
-		r.requestBundles()
 	}
 }
 


### PR DESCRIPTION
When using AutoReconnect, the relay doesn't resubscribe to the topic. In some cases the topic in cog has gone away due to an error causing the erlang process to die, and without a resubscribe that topic will not get recreated. The mqtt.go changes fix this by setting the OnConnect handler, so on every connection it makes sure that it's subscribed.

The relay.go change fixes a bug that causes multiple publishers to exist for the bundle updater, which can end up causing the client to start sending massive amounts of announcements.